### PR TITLE
V0.1.4 Player Rating Comparison Tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: win-v0.1.2.${{ github.run_number }}
-          name: Windows Release v0.1.2.${{ github.run_number }}
+          tag_name: win-v0.1.4.${{ github.run_number }}
+          name: Windows Release v0.1.4.${{ github.run_number }}
           files: installer/Output/*.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ this becomes obsolete.
 - Similar to the batting and pitching stats, the user is able to select which stats they want to view
   - Default stats always visible are team games play, wins, losses and winning percentage
 
+
+### Rating Comparison Tool
+
+- The rating comparison tool allows the user to compare ratings across various categories and to select which cards are eligible.
+- The settings for target_card_list_file MUST be directed to the dump from the OOTP card shop.
+
 ___
 # Release Information
 
@@ -159,13 +165,18 @@ ___
 - Display trends for individual batters and pitchers over time
 - Add card rating min and max tool on main stats page
 
+### v0.1.4.34 (Windows), v0.1.4.18 (macOS), v0.1.4.10 (macOS Intel)
+
+- Add functionality for comparing card ratings from card shop and ability to weight ratings for the user's intended tournament  format.
+- Fixed issue where team stats would not populate for small volume datasets.
+
 ---
 
 ## Upcoming Features and Improvements
 
 - Team analysis
-- Player comparison tool
-- Player and tournament statistics over time
+- Player comparison tool (Complete v0.1.4)
+- Player and tournament statistics over time (baseline complete v0.1.2)
 
 ### Authored By
 - David Wright

--- a/apps/basic_batting_stats_view.py
+++ b/apps/basic_batting_stats_view.py
@@ -523,7 +523,6 @@ class BasicStatsView(ctk.CTkToplevel):
         """Get the list of selected general stats."""
         return self.general_stats_select_frame.get_selected_general_stats()
 
-
     def load_data_to_store(self):
         """Process file for team list."""
         if not self.target_file:

--- a/apps/player_rating_tool_view.py
+++ b/apps/player_rating_tool_view.py
@@ -5,7 +5,9 @@ from utils.view_utils.header_footer_frame import Header, Footer
 from utils.view_utils.all_player_data_view_frame import TreeviewTableFrame
 from utils.data_utils.card_list_store import card_store
 from utils.view_utils.ratings_menu_frame import RatingsMenuFrame
-from utils.stats_utils.calculate_return_rating_values import calculate_return_rating_values
+from utils.stats_utils.calculate_return_rating_values import (
+    calculate_return_rating_values
+)
 
 
 class PlayerRatingToolView(ctk.CTkToplevel):
@@ -79,7 +81,6 @@ class PlayerRatingToolView(ctk.CTkToplevel):
         self.menu_frame.columnconfigure(0, weight=1)
         self.menu_frame.columnconfigure(1, weight=0)
 
-
         self.footer_frame = Footer(
             self,
             height=header_footer_height,
@@ -141,7 +142,6 @@ class PlayerRatingToolView(ctk.CTkToplevel):
             self.after(100, release)
 
         show_and_release_topmost()
-
 
     def update_view(self):
         """Update the view."""

--- a/apps/player_rating_tool_view.py
+++ b/apps/player_rating_tool_view.py
@@ -1,0 +1,160 @@
+"""App for comparing player ratings across collection."""
+import customtkinter as ctk
+from utils.config_utils import settings as settings_module
+from utils.view_utils.header_footer_frame import Header, Footer
+from utils.view_utils.all_player_data_view_frame import TreeviewTableFrame
+from utils.data_utils.card_list_store import card_store
+from utils.view_utils.ratings_menu_frame import RatingsMenuFrame
+from utils.stats_utils.calculate_return_rating_values import calculate_return_rating_values
+
+
+class PlayerRatingToolView(ctk.CTkToplevel):
+    """Base class for the view."""
+
+    def __init__(self):
+        """Initialize the class."""
+        super().__init__()
+
+        page_settings = settings_module.settings
+
+        # Get the card list
+        card_store.load_card_list()
+        self.card_df = card_store.get_all_card_ratings()
+
+        self.height = int(page_settings['FileProcessor']['height'])
+        self.width = int(page_settings['FileProcessor']['width'])
+        self.frame_width = int(int(self.width) * .9)
+        self.initial_target_dir = (
+            page_settings['InitialFileDirs']['initial_target_folder'])
+        header_footer_height = int(int(self.height) * .1)
+
+        self.title = 'Basic Stats View'
+        self.geometry(f"{self.width}x{self.height}")
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=0)
+        self.rowconfigure(0, weight=0)
+        self.rowconfigure(1, weight=1)
+        self.rowconfigure(2, weight=0)
+
+        # Set up the necessary frames
+        self.header_frame = Header(
+            self,
+            height=header_footer_height,
+            width=int(self.frame_width),
+            title=self.title
+        )
+        self.header_frame.grid(
+            row=0,
+            column=0,
+            columnspan=3,
+            padx=10,
+            pady=10,
+            sticky='nsew'
+        )
+
+        self.data_view_frame = TreeviewTableFrame(self)
+        self.data_view_frame.grid(
+            row=1,
+            column=0,
+            columnspan=2,
+            padx=10,
+            pady=10,
+            sticky='nsew')
+
+        self.menu_frame = ctk.CTkFrame(
+            self
+        )
+        self.menu_frame.grid(
+            row=1,
+            column=2,
+            padx=5,
+            pady=5,
+            sticky='nsew'
+        )
+
+        self.menu_frame.columnconfigure(0, weight=1)
+        self.menu_frame.columnconfigure(1, weight=0)
+
+
+        self.footer_frame = Footer(
+            self,
+            height=header_footer_height,
+            width=int(self.frame_width),
+        )
+        self.footer_frame.grid(
+            row=2,
+            column=0,
+            columnspan=3,
+            padx=10,
+            pady=10,
+            sticky='nsew'
+        )
+
+        # Put the required items in the frames
+
+        self.ratings_menu = RatingsMenuFrame(
+            self.menu_frame,
+        )
+        self.ratings_menu.grid(
+            row=0,
+            column=0,
+            padx=0,
+            pady=20,
+            sticky='nsew'
+        )
+
+        self.update_button = ctk.CTkButton(
+            self.menu_frame,
+            command=self.update_view,
+        )
+        self.update_button.grid(
+            row=3,
+            column=0,
+            padx=10,
+            pady=10,
+        )
+
+        self.update_view()
+
+        def show_and_release_topmost():
+            """Lift window, set topmost and then release safely."""
+            if not self.winfo_exists():
+                return
+
+            try:
+                self.lift()
+                self.attributes("-topmost", True)
+            except Exception():
+                return
+
+            def release():
+                if self.winfo_exists():
+                    try:
+                        self.attributes("-topmost", False)
+                    except Exception:
+                        pass
+
+            self.after(100, release)
+
+        show_and_release_topmost()
+
+
+    def update_view(self):
+        """Update the view."""
+        ratings_to_view = self.ratings_menu.get_active_ratings()
+        batter_weights = self.ratings_menu.get_batting_weights()
+        pitcher_weights = self.ratings_menu.get_pitching_weights()
+        defense_weights = self.ratings_menu.get_defense_weights()
+        min_value, max_value = self.ratings_menu.get_min_max_values()
+        ratings_df = calculate_return_rating_values(
+            self.card_df,
+            ratings_to_view=ratings_to_view,
+            min_rating=min_value,
+            max_rating=max_value,
+            batting_weights=batter_weights,
+            pitching_weights=pitcher_weights,
+            defense_weights=defense_weights,
+        )
+        self.data_view_frame.load_dataframe(ratings_df)

--- a/apps/player_rating_tool_view.py
+++ b/apps/player_rating_tool_view.py
@@ -63,8 +63,10 @@ class PlayerRatingToolView(ctk.CTkToplevel):
             pady=10,
             sticky='nsew')
 
-        self.menu_frame = ctk.CTkFrame(
-            self
+        self.menu_frame = ctk.CTkScrollableFrame(
+            self,
+            width=300,
+            height=self.height,
         )
         self.menu_frame.grid(
             row=1,
@@ -102,7 +104,7 @@ class PlayerRatingToolView(ctk.CTkToplevel):
             column=0,
             padx=0,
             pady=20,
-            sticky='nsew'
+            sticky='ns'
         )
 
         self.update_button = ctk.CTkButton(
@@ -148,13 +150,20 @@ class PlayerRatingToolView(ctk.CTkToplevel):
         pitcher_weights = self.ratings_menu.get_pitching_weights()
         defense_weights = self.ratings_menu.get_defense_weights()
         min_value, max_value = self.ratings_menu.get_min_max_values()
+        min_year, max_year = self.ratings_menu.get_min_max_year()
+        selected_position = self.ratings_menu.get_selected_position()
+        selected_card_type = self.ratings_menu.get_selected_card_type()
         ratings_df = calculate_return_rating_values(
             self.card_df,
             ratings_to_view=ratings_to_view,
             min_rating=min_value,
             max_rating=max_value,
+            min_year=min_year,
+            max_year=max_year,
             batting_weights=batter_weights,
             pitching_weights=pitcher_weights,
             defense_weights=defense_weights,
+            position=selected_position,
+            selected_card_types=selected_card_type,
         )
         self.data_view_frame.load_dataframe(ratings_df)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import customtkinter as ctk
 from apps.basic_batting_stats_view import BasicStatsView
 from apps.basic_pitching_stats_view import BasicPitchingStatsView
 from apps.basic_team_stats import BasicTeamStatsView
+from apps.player_rating_tool_view import PlayerRatingToolView
 from utils.config_utils.get_base_sys_path import get_base_sys_path
 
 sys.path.insert(0, get_base_sys_path())
@@ -187,6 +188,17 @@ class MainApp(ctk.CTk):
             column=0, row=1, padx=10, pady=10, sticky='nsew'
         )
 
+        self.rating_comparison_view_button = (
+            AppSelectButton(
+                self.main_frame,
+                command=open_rating_comparison_stats_view,
+                text="Rating Comparison Stats View"
+            )
+        )
+        self.rating_comparison_view_button.grid(
+            column=1, row=1, padx=10, pady=10, sticky='nsew'
+        )
+
         def show_and_release_topmost():
             """Lift window, set topmost and then release safely."""
             if not self.winfo_exists():
@@ -229,6 +241,9 @@ def open_basic_teams_stats_view():
     """Open the basic teams stats view app in a new window."""
     BasicTeamStatsView()
 
+def open_rating_comparison_stats_view():
+    """Open the rating comparison stats view app in a new window."""
+    PlayerRatingToolView()
 
 if __name__ == "__main__":
     app = MainApp()

--- a/main.py
+++ b/main.py
@@ -241,9 +241,11 @@ def open_basic_teams_stats_view():
     """Open the basic teams stats view app in a new window."""
     BasicTeamStatsView()
 
+
 def open_rating_comparison_stats_view():
     """Open the rating comparison stats view app in a new window."""
     PlayerRatingToolView()
+
 
 if __name__ == "__main__":
     app = MainApp()

--- a/main.py
+++ b/main.py
@@ -192,7 +192,7 @@ class MainApp(ctk.CTk):
             AppSelectButton(
                 self.main_frame,
                 command=open_rating_comparison_stats_view,
-                text="Rating Comparison Stats View"
+                text="Rating Comparison View"
             )
         )
         self.rating_comparison_view_button.grid(

--- a/utils/data_utils/card_list_store.py
+++ b/utils/data_utils/card_list_store.py
@@ -27,5 +27,9 @@ class CardListStore:
 
         return df1
 
+    def get_all_card_ratings(self):
+        """Get a dataframe of all card ratings."""
+        return self._card_list_dataframe
+
 
 card_store = CardListStore()

--- a/utils/stats_utils/calc_basic_pitching_stats.py
+++ b/utils/stats_utils/calc_basic_pitching_stats.py
@@ -2,7 +2,7 @@
 # import pandas as pd
 
 
-def calc_basic_pitching_stats(df, min_ip=200, inning_split=5, role=None):
+def calc_basic_pitching_stats(df, min_ip=0, inning_split=5, role=None):
     """Calculate basic batting stats and return a dataframe."""
     df1 = df.copy()
 

--- a/utils/stats_utils/calculate_return_rating_values.py
+++ b/utils/stats_utils/calculate_return_rating_values.py
@@ -1,0 +1,113 @@
+"""Calculate rating values using user weights."""
+import pandas as pd
+
+
+def calculate_return_rating_values(
+        df,
+        ratings_to_view=None,
+        min_rating=40,
+        max_rating=105,
+        batting_weights=None,
+        pitching_weights=None,
+        defense_weights=None
+):
+    """Calculate ratings and return a dataframe with requested ratings."""
+    columns_to_keep = ['CID', 'Title', 'Val']
+    columns_to_keep.extend(ratings_to_view)
+
+    df1 = df.copy()
+    df1 = df1[['Card ID', "//Card Title", 'Card Value', 'Card Type', 'Year', 'Bats', 'Throws',
+               'Contact', 'Gap', 'Power', 'Eye', 'Avoid Ks', 'BABIP', 'Contact vL', 'Gap vL', 'Power vL',
+               'Eye vL', 'Avoid K vL', 'BABIP vL', 'Contact vR', 'Gap vR', 'Power vR', 'Eye vR',
+               'Avoid K vR', 'BABIP vR', 'Speed', 'Steal Rate', 'Stealing', 'Baserunning',
+               'CatcherAbil', 'CatcherFrame', 'Catcher Arm', 'Infield Range', 'Infield Error',
+               'Infield Arm', 'DP', 'OF Range', 'OF Error', 'OF Arm', 'Stuff', 'pHR', 'pBABIP',
+               'Control', 'Stuff vL', 'pHR vL', 'pBABIP vL', 'Control vL', 'Stuff vR', 'pHR vR',
+               'pBABIP vR', 'Control vR']]
+    df1 = df1.rename(columns={'Card ID': 'CID', "//Card Title": "Title", 'Card Value': 'Val'})
+    df1 = df1[(df1['Val'] >= int(min_rating)) & (df1['Val'] <= int(max_rating))]
+
+    calculate_batting_overall_rating(df1, batting_weights)
+    calculate_batting_vs_left_rating(df1, batting_weights)
+    calculate_batting_vs_right_rating(df1, batting_weights)
+    calculate_baserunning(df1)
+    calculate_catcher_defense(df1, defense_weights)
+    calculate_infield_defense(df1, defense_weights)
+    calculate_outfield_defense(df1, defense_weights)
+    calculate_pitching_overall(df1, pitching_weights)
+    calculate_pitching_vs_left(df1, pitching_weights)
+    calculate_pitching_vs_right(df1, pitching_weights)
+
+    df2 = df1[columns_to_keep]
+    del df1
+    return df2
+
+
+def calculate_batting_overall_rating(df, weights):
+    df['BatOA'] = (
+            (df['BABIP'] * weights['BABIP']) +
+            (df['Avoid Ks'] * weights['Avoid Ks']) +
+            (df['Gap'] * weights['Gap']) +
+            (df['Power'] * weights['Power']) +
+            (df['Eye'] * weights['Eye'])
+    )
+
+def calculate_batting_vs_left_rating(df, weights):
+    df['BatvL'] = (
+        (df['BABIP vL'] * weights['BABIP vL']) +
+        (df['Avoid K vL'] * weights['Avoid K vL']) +
+        (df['Gap vL'] * weights['Gap vL']) +
+        (df['Power vL'] * weights['Power vL']) +
+        (df['Eye vL'] * weights['Eye vL'])
+    )
+
+def calculate_batting_vs_right_rating(df, weights):
+    df['BatvR'] = (
+        (df['BABIP vR'] * weights['BABIP vR']) +
+        (df['Avoid K vR'] * weights['Avoid K vR']) +
+        (df['Gap vR'] * weights['Gap vR']) +
+        (df['Power vR'] * weights['Power vR']) +
+        (df['Eye vR'] * weights['Eye vR'])
+    )
+
+def calculate_baserunning(df):
+    df['BSR'] = df['Speed'] + df['Steal Rate'] + df['Stealing'] + df['Baserunning']
+
+def calculate_catcher_defense(df, weights):
+    df['Catch Def'] = (
+        (df['CatcherAbil'] * weights['CatchAbil']) +
+        (df['CatcherFrame'] * weights['CatchFrame']) +
+        (df['Catcher Arm'] * weights['CatchArm'])
+    )
+
+def calculate_infield_defense(df, weights):
+    df['IF Def'] = (
+        (df['Infield Range'] * weights['IF Range']) +
+        (df['Infield Error'] * weights['IF Error']) +
+        (df['Infield Arm'] * weights['IF Arm']) +
+        (df['DP'] * weights['DP'])
+    )
+
+def calculate_outfield_defense(df, weights):
+    df['OF Def'] = (
+        (df['OF Range'] * weights['OF Range']) +
+        (df['OF Error'] * weights['OF Error']) +
+        (df['OF Arm'] * weights['OF Arm'])
+    )
+
+def calculate_pitching_overall(df, pitching_weights):
+    df['PitOA'] = (
+        (df['Stuff'] * pitching_weights['Stuff']) +
+        (df['pHR'] * pitching_weights['pHR']) +
+        (df['pBABIP'] * pitching_weights['pBABIP']) +
+        (df['Control'] * pitching_weights['Control'])
+    )
+
+def calculate_pitching_vs_left(df, pitching_weights):
+    df['PitvL'] = df['Stuff vL'] + df['pHR vL'] + df['pBABIP vL'] + df['Control vL']
+
+def calculate_pitching_vs_right(df, pitching_weights):
+    df['PitvR'] = df['Stuff vR'] + df['pHR vR'] + df['pBABIP vR'] + df['Control vR']
+
+
+

--- a/utils/stats_utils/calculate_return_rating_values.py
+++ b/utils/stats_utils/calculate_return_rating_values.py
@@ -19,21 +19,27 @@ def calculate_return_rating_values(
     columns_to_keep = ['CID', 'Title', 'Val']
     columns_to_keep.extend(ratings_to_view)
     df1 = df.copy()
-    df1 = df1[['Card ID', "//Card Title", 'Card Value', 'Card Type', 'Year', 'Position', 'Bats', 'Throws',
-               'Contact', 'Gap', 'Power', 'Eye', 'Avoid Ks', 'BABIP', 'Contact vL', 'Gap vL', 'Power vL',
-               'Eye vL', 'Avoid K vL', 'BABIP vL', 'Contact vR', 'Gap vR', 'Power vR', 'Eye vR',
-               'Avoid K vR', 'BABIP vR', 'Speed', 'Steal Rate', 'Stealing', 'Baserunning',
-               'CatcherAbil', 'CatcherFrame', 'Catcher Arm', 'Infield Range', 'Infield Error',
-               'Infield Arm', 'DP', 'OF Range', 'OF Error', 'OF Arm', 'Stuff', 'pHR', 'pBABIP',
-               'Control', 'Stuff vL', 'pHR vL', 'pBABIP vL', 'Control vL', 'Stuff vR', 'pHR vR',
-               'pBABIP vR', 'Control vR', 'LearnC', 'Learn1B', 'Learn2B', 'Learn3B', 'LearnSS',
-               'LearnLF', 'LearnCF', 'LearnRF', 'date']]
-    df1 = df1.rename(columns={'Card ID': 'CID', "//Card Title": "Title", 'Card Value': 'Val'})
-    df1 = df1[(df1['Val'] >= int(min_rating)) & (df1['Val'] <= int(max_rating))]
-    df1 = df1[(df1['Year'] >= int(min_year)) & (df1['Year'] <= int(max_year))]
+    df1 = df1[['Card ID', "//Card Title", 'Card Value', 'Card Type',
+               'Year', 'Position', 'Bats', 'Throws', 'Contact', 'Gap',
+               'Power', 'Eye', 'Avoid Ks', 'BABIP', 'Contact vL', 'Gap vL',
+               'Power vL', 'Eye vL', 'Avoid K vL', 'BABIP vL', 'Contact vR',
+               'Gap vR', 'Power vR', 'Eye vR', 'Avoid K vR', 'BABIP vR',
+               'Speed', 'Steal Rate', 'Stealing', 'Baserunning', 'CatcherAbil',
+               'CatcherFrame', 'Catcher Arm', 'Infield Range', 'Infield Error',
+               'Infield Arm', 'DP', 'OF Range', 'OF Error', 'OF Arm', 'Stuff',
+               'pHR', 'pBABIP', 'Control', 'Stuff vL', 'pHR vL', 'pBABIP vL',
+               'Control vL', 'Stuff vR', 'pHR vR', 'pBABIP vR', 'Control vR',
+               'LearnC', 'Learn1B', 'Learn2B', 'Learn3B', 'LearnSS', 'LearnLF',
+               'LearnCF', 'LearnRF', 'date']]
+    df1 = df1.rename(columns={'Card ID': 'CID', "//Card Title": "Title",
+                              'Card Value': 'Val'})
+    df1 = df1[(df1['Val'] >= int(min_rating)) &
+              (df1['Val'] <= int(max_rating))]
+    df1 = df1[(df1['Year'] >= int(min_year)) &
+              (df1['Year'] <= int(max_year))]
 
     columns_list = df1.columns.tolist()
-    df2 = pd.DataFrame(columns = columns_list)
+    df2 = pd.DataFrame(columns=columns_list)
 
     if selected_card_types:
         for card_type in selected_card_types:
@@ -70,6 +76,7 @@ def calculate_return_rating_values(
 
 
 def calculate_batting_overall_rating(df, weights):
+    """Calculate ratings for overall batting."""
     df['BatOA'] = (
             (df['BABIP'] * weights['BABIP']) +
             (df['Avoid Ks'] * weights['Avoid Ks']) +
@@ -78,7 +85,9 @@ def calculate_batting_overall_rating(df, weights):
             (df['Eye'] * weights['Eye'])
     )
 
+
 def calculate_batting_vs_left_rating(df, weights):
+    """Calculate vs left rating for batting."""
     df['BatvL'] = (
         (df['BABIP vL'] * weights['BABIP vL']) +
         (df['Avoid K vL'] * weights['Avoid K vL']) +
@@ -87,7 +96,9 @@ def calculate_batting_vs_left_rating(df, weights):
         (df['Eye vL'] * weights['Eye vL'])
     )
 
+
 def calculate_batting_vs_right_rating(df, weights):
+    """Calculate vs right rating for batting."""
     df['BatvR'] = (
         (df['BABIP vR'] * weights['BABIP vR']) +
         (df['Avoid K vR'] * weights['Avoid K vR']) +
@@ -96,20 +107,29 @@ def calculate_batting_vs_right_rating(df, weights):
         (df['Eye vR'] * weights['Eye vR'])
     )
 
+
 def calculate_batting_split(df):
+    """Calculate batting splits."""
     df['BSplit'] = df['BatvL'] - df['BatvR']
 
+
 def calculate_baserunning(df):
-    df['BSR'] = df['Speed'] + df['Steal Rate'] + df['Stealing'] + df['Baserunning']
+    """Calculate baserunning."""
+    df['BSR'] = (df['Speed'] + df['Steal Rate'] +
+                 df['Stealing'] + df['Baserunning'])
+
 
 def calculate_catcher_defense(df, weights):
+    """Calculate catcher defense."""
     df['Catch Def'] = (
         (df['CatcherAbil'] * weights['CatchAbil']) +
         (df['CatcherFrame'] * weights['CatchFrame']) +
         (df['Catcher Arm'] * weights['CatchArm'])
     )
 
+
 def calculate_infield_defense(df, weights):
+    """Calculate infield defense."""
     df['IF Def'] = (
         (df['Infield Range'] * weights['IF Range']) +
         (df['Infield Error'] * weights['IF Error']) +
@@ -117,14 +137,18 @@ def calculate_infield_defense(df, weights):
         (df['DP'] * weights['DP'])
     )
 
+
 def calculate_outfield_defense(df, weights):
+    """Calculate outfield defense."""
     df['OF Def'] = (
         (df['OF Range'] * weights['OF Range']) +
         (df['OF Error'] * weights['OF Error']) +
         (df['OF Arm'] * weights['OF Arm'])
     )
 
+
 def calculate_pitching_overall(df, pitching_weights):
+    """Calculate pitching overall."""
     df['PitOA'] = (
         (df['Stuff'] * pitching_weights['Stuff']) +
         (df['pHR'] * pitching_weights['pHR']) +
@@ -132,15 +156,19 @@ def calculate_pitching_overall(df, pitching_weights):
         (df['Control'] * pitching_weights['Control'])
     )
 
+
 def calculate_pitching_vs_left(df, pitching_weights):
+    """Calculate pitching vs left."""
     df['PitvL'] = (
-        (df['Stuff vL']  * pitching_weights['Stuff vL']) +
+        (df['Stuff vL'] * pitching_weights['Stuff vL']) +
         (df['pHR vL'] * pitching_weights['pHR vL']) +
         (df['pBABIP vL'] * pitching_weights['pBABIP vL']) +
         (df['Control vL'] * pitching_weights['Control vL'])
     )
 
+
 def calculate_pitching_vs_right(df, pitching_weights):
+    """Calculate pitching vs right."""
     df['PitvR'] = (
         (df['Stuff vR'] * pitching_weights['Stuff vR']) +
         (df['pHR vR'] * pitching_weights['pHR vR']) +
@@ -148,8 +176,7 @@ def calculate_pitching_vs_right(df, pitching_weights):
         (df['Control vR'] * pitching_weights['Control vR'])
     )
 
+
 def calculate_pitching_splits(df):
+    """Calculate pitching splits."""
     df['PSplit'] = df['PitvL'] - df['PitvR']
-
-
-

--- a/utils/stats_utils/calculate_return_rating_values.py
+++ b/utils/stats_utils/calculate_return_rating_values.py
@@ -7,38 +7,64 @@ def calculate_return_rating_values(
         ratings_to_view=None,
         min_rating=40,
         max_rating=105,
+        min_year=1850,
+        max_year=2025,
         batting_weights=None,
         pitching_weights=None,
-        defense_weights=None
+        defense_weights=None,
+        position=None,
+        selected_card_types=None,
 ):
     """Calculate ratings and return a dataframe with requested ratings."""
     columns_to_keep = ['CID', 'Title', 'Val']
     columns_to_keep.extend(ratings_to_view)
-
     df1 = df.copy()
-    df1 = df1[['Card ID', "//Card Title", 'Card Value', 'Card Type', 'Year', 'Bats', 'Throws',
+    df1 = df1[['Card ID', "//Card Title", 'Card Value', 'Card Type', 'Year', 'Position', 'Bats', 'Throws',
                'Contact', 'Gap', 'Power', 'Eye', 'Avoid Ks', 'BABIP', 'Contact vL', 'Gap vL', 'Power vL',
                'Eye vL', 'Avoid K vL', 'BABIP vL', 'Contact vR', 'Gap vR', 'Power vR', 'Eye vR',
                'Avoid K vR', 'BABIP vR', 'Speed', 'Steal Rate', 'Stealing', 'Baserunning',
                'CatcherAbil', 'CatcherFrame', 'Catcher Arm', 'Infield Range', 'Infield Error',
                'Infield Arm', 'DP', 'OF Range', 'OF Error', 'OF Arm', 'Stuff', 'pHR', 'pBABIP',
                'Control', 'Stuff vL', 'pHR vL', 'pBABIP vL', 'Control vL', 'Stuff vR', 'pHR vR',
-               'pBABIP vR', 'Control vR']]
+               'pBABIP vR', 'Control vR', 'LearnC', 'Learn1B', 'Learn2B', 'Learn3B', 'LearnSS',
+               'LearnLF', 'LearnCF', 'LearnRF', 'date']]
     df1 = df1.rename(columns={'Card ID': 'CID', "//Card Title": "Title", 'Card Value': 'Val'})
     df1 = df1[(df1['Val'] >= int(min_rating)) & (df1['Val'] <= int(max_rating))]
+    df1 = df1[(df1['Year'] >= int(min_year)) & (df1['Year'] <= int(max_year))]
 
-    calculate_batting_overall_rating(df1, batting_weights)
-    calculate_batting_vs_left_rating(df1, batting_weights)
-    calculate_batting_vs_right_rating(df1, batting_weights)
-    calculate_baserunning(df1)
-    calculate_catcher_defense(df1, defense_weights)
-    calculate_infield_defense(df1, defense_weights)
-    calculate_outfield_defense(df1, defense_weights)
-    calculate_pitching_overall(df1, pitching_weights)
-    calculate_pitching_vs_left(df1, pitching_weights)
-    calculate_pitching_vs_right(df1, pitching_weights)
+    columns_list = df1.columns.tolist()
+    df2 = pd.DataFrame(columns = columns_list)
 
-    df2 = df1[columns_to_keep]
+    if selected_card_types:
+        for card_type in selected_card_types:
+            df2 = pd.concat([df2, df1[df1['Card Type'] == card_type]])
+    else:
+        df2 = df1.copy()
+
+    # Get the cards for the selected position.
+    if position == '':
+        pass
+    elif position == 'Batters':
+        pass
+    elif position == 'LearnP':
+        df2 = df2[df2['Position'] == 1]
+    else:
+        df2 = df2[df2[position] == 1]
+
+    calculate_batting_overall_rating(df2, batting_weights)
+    calculate_batting_vs_left_rating(df2, batting_weights)
+    calculate_batting_vs_right_rating(df2, batting_weights)
+    calculate_batting_split(df2)
+    calculate_baserunning(df2)
+    calculate_catcher_defense(df2, defense_weights)
+    calculate_infield_defense(df2, defense_weights)
+    calculate_outfield_defense(df2, defense_weights)
+    calculate_pitching_overall(df2, pitching_weights)
+    calculate_pitching_vs_left(df2, pitching_weights)
+    calculate_pitching_vs_right(df2, pitching_weights)
+    calculate_pitching_splits(df2)
+
+    df2 = df2[columns_to_keep]
     del df1
     return df2
 
@@ -69,6 +95,9 @@ def calculate_batting_vs_right_rating(df, weights):
         (df['Power vR'] * weights['Power vR']) +
         (df['Eye vR'] * weights['Eye vR'])
     )
+
+def calculate_batting_split(df):
+    df['BSplit'] = df['BatvL'] - df['BatvR']
 
 def calculate_baserunning(df):
     df['BSR'] = df['Speed'] + df['Steal Rate'] + df['Stealing'] + df['Baserunning']
@@ -104,10 +133,23 @@ def calculate_pitching_overall(df, pitching_weights):
     )
 
 def calculate_pitching_vs_left(df, pitching_weights):
-    df['PitvL'] = df['Stuff vL'] + df['pHR vL'] + df['pBABIP vL'] + df['Control vL']
+    df['PitvL'] = (
+        (df['Stuff vL']  * pitching_weights['Stuff vL']) +
+        (df['pHR vL'] * pitching_weights['pHR vL']) +
+        (df['pBABIP vL'] * pitching_weights['pBABIP vL']) +
+        (df['Control vL'] * pitching_weights['Control vL'])
+    )
 
 def calculate_pitching_vs_right(df, pitching_weights):
-    df['PitvR'] = df['Stuff vR'] + df['pHR vR'] + df['pBABIP vR'] + df['Control vR']
+    df['PitvR'] = (
+        (df['Stuff vR'] * pitching_weights['Stuff vR']) +
+        (df['pHR vR'] * pitching_weights['pHR vR']) +
+        (df['pBABIP vR'] * pitching_weights['pBABIP vR']) +
+        (df['Control vR'] * pitching_weights['Control vR'])
+    )
+
+def calculate_pitching_splits(df):
+    df['PSplit'] = df['PitvL'] - df['PitvR']
 
 
 

--- a/utils/stats_utils/cull_teams.py
+++ b/utils/stats_utils/cull_teams.py
@@ -3,7 +3,6 @@
 
 def cull_teams(df):
     """Cull teams that have more than the given number of runs."""
-    print("Total length: ", len(df))
     team_stats = df.groupby(['ORG', 'Trny'],
                             as_index=False)[['GS.1', 'R']].sum()
     team_stats['R/G'] = team_stats['R'] / team_stats['GS.1']
@@ -14,7 +13,5 @@ def cull_teams(df):
     # Merge to flag rows to drop
     df1_filtered = df.merge(teams_ok, on=['ORG', 'Trny'], how='inner')
     removed_count = len(df) - len(df1_filtered)
-
-    print("removed count: ", removed_count)
 
     return df1_filtered, removed_count

--- a/utils/stats_utils/cull_teams.py
+++ b/utils/stats_utils/cull_teams.py
@@ -3,6 +3,7 @@
 
 def cull_teams(df):
     """Cull teams that have more than the given number of runs."""
+    print("Total length: ", len(df))
     team_stats = df.groupby(['ORG', 'Trny'],
                             as_index=False)[['GS.1', 'R']].sum()
     team_stats['R/G'] = team_stats['R'] / team_stats['GS.1']
@@ -13,5 +14,7 @@ def cull_teams(df):
     # Merge to flag rows to drop
     df1_filtered = df.merge(teams_ok, on=['ORG', 'Trny'], how='inner')
     removed_count = len(df) - len(df1_filtered)
+
+    print("removed count: ", removed_count)
 
     return df1_filtered, removed_count

--- a/utils/stats_utils/display_basic_player_batting_stats.py
+++ b/utils/stats_utils/display_basic_player_batting_stats.py
@@ -24,13 +24,14 @@ def display_basic_batting_stats(
     card_df_path = script_settings['InitialFileDirs']['target_card_list_file']
     card_df = pd.DataFrame(pd.read_csv(card_df_path))
     card_df = card_df.rename(
-        columns={'Card ID': 'CID', '//Card Title': 'Title', 'Last 10 Price': 'L10',
-                 'Last 10 Price(VAR)': 'L10V'}
+        columns={'Card ID': 'CID', '//Card Title': 'Title',
+                 'Last 10 Price': 'L10', 'Last 10 Price(VAR)': 'L10V'}
     )
 
     df2, removed = cull_teams(pd.DataFrame(df1))
 
-    columns_from_data = ['CID', 'Title', 'Card Value', 'Bats', 'owned', 'L10', 'L10V']
+    columns_from_data = ['CID', 'Title', 'Card Value', 'Bats',
+                         'owned', 'L10', 'L10V']
 
     # Calculate the basic statistics
     if not variant_split:

--- a/utils/stats_utils/display_basic_player_pitching_stats.py
+++ b/utils/stats_utils/display_basic_player_pitching_stats.py
@@ -24,8 +24,8 @@ def display_basic_pitching_stats(
     card_df_path = script_settings['InitialFileDirs']['target_card_list_file']
     card_df = pd.DataFrame(pd.read_csv(card_df_path))
     card_df = card_df.rename(
-        columns={'Card ID': 'CID', '//Card Title': 'Title', 'Last 10 Price': 'L10',
-                 'Last 10 Price(VAR)': 'L10V'}
+        columns={'Card ID': 'CID', '//Card Title': 'Title',
+                 'Last 10 Price': 'L10', 'Last 10 Price(VAR)': 'L10V'}
     )
 
     def innings_calc(innings):
@@ -35,7 +35,8 @@ def display_basic_pitching_stats(
 
     # Set columns for whether variants will be split or not
     if variant_split:
-        columns_to_keep = ['CID', 'Title', 'VLvl', 'Card Value', 'Throws', 'IPC']
+        columns_to_keep = ['CID', 'Title', 'VLvl',
+                           'Card Value', 'Throws', 'IPC']
     else:
         columns_to_keep = ['CID', 'Title', 'Card Value', 'Throws', 'IPC']
 
@@ -71,7 +72,8 @@ def display_basic_pitching_stats(
     df2 = calc_basic_pitching_stats(df2, min_ip, inning_split, role)
 
     df3 = pd.merge(
-        card_df[['CID', 'Title', 'Card Value', 'Throws', 'owned', 'L10', 'L10V']],
+        card_df[['CID', 'Title', 'Card Value', 'Throws',
+                 'owned', 'L10', 'L10V']],
         df2,
         on='CID',
         how='inner'

--- a/utils/stats_utils/display_basic_team_stats.py
+++ b/utils/stats_utils/display_basic_team_stats.py
@@ -39,6 +39,7 @@ def display_basic_team_stats(df,
     df3 = calc_basic_batting_stats(df3)
     df3 = calc_basic_pitching_stats(df3)
 
+
     df4 = pd.merge(df1, df3, on='ORG', how='left')
 
     df4 = df4[columns_to_keep]

--- a/utils/stats_utils/display_basic_team_stats.py
+++ b/utils/stats_utils/display_basic_team_stats.py
@@ -39,7 +39,6 @@ def display_basic_team_stats(df,
     df3 = calc_basic_batting_stats(df3)
     df3 = calc_basic_pitching_stats(df3)
 
-
     df4 = pd.merge(df1, df3, on='ORG', how='left')
 
     df4 = df4[columns_to_keep]

--- a/utils/view_utils/all_player_data_view_frame.py
+++ b/utils/view_utils/all_player_data_view_frame.py
@@ -156,7 +156,7 @@ class TreeviewTableFrame(ctk.CTkFrame):
         try:
             role = self.parent.role
         except ValueError:
-            role = "batter"
+            role = None
 
         values = self.tree.item(selected_item, 'values')
         columns = self.tree['columns']
@@ -164,9 +164,12 @@ class TreeviewTableFrame(ctk.CTkFrame):
         try:
             cid_index = columns.index("CID")
             cid_value = values[cid_index]
-        except ValueError:
+        except Exception as e:
+            print("Index error on player select: ", e)
             return
         if role == 'batter':
             open_batter_view(cid_value, file_path, self.team_to_highlight)
         elif role == 'pitcher':
             open_pitcher_view(cid_value, file_path, self.team_to_highlight)
+        elif role is None:
+            return

--- a/utils/view_utils/batting_weights_frame.py
+++ b/utils/view_utils/batting_weights_frame.py
@@ -1,0 +1,195 @@
+"""Custom frame for users to enter batting weights."""
+import customtkinter as ctk
+
+class BattingWeightsFrame(ctk.CTkFrame):
+    """Frame for users to enter batting weights."""
+
+    def __init__(self, parent):
+        ctk.CTkFrame.__init__(self, parent)
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
+        self.columnconfigure(3, weight=1)
+
+        # Variables for the weights
+        self.babip_overall_var = ctk.StringVar(value='1')
+        self.babip_v_left_var = ctk.StringVar(value='1')
+        self.babip_v_right_var = ctk.StringVar(value='1')
+        self.avoid_k_overall_var = ctk.StringVar(value='1')
+        self.avoid_k_left_var = ctk.StringVar(value='1')
+        self.avoid_k_right_var = ctk.StringVar(value='1')
+        self.gap_overall_var = ctk.StringVar(value='1')
+        self.gap_v_left_var = ctk.StringVar(value='1')
+        self.gap_v_right_var = ctk.StringVar(value='1')
+        self.power_overall_var = ctk.StringVar(value='1')
+        self.power_v_left_var = ctk.StringVar(value='1')
+        self.power_v_right_var = ctk.StringVar(value='1')
+        self.eye_overall_var = ctk.StringVar(value='1')
+        self.eye_v_left_var = ctk.StringVar(value='1')
+        self.eye_v_right_var = ctk.StringVar(value='1')
+
+
+        # Left side labels
+        frame_label = ctk.CTkLabel(self, text='Bat Weights')
+        frame_label.grid(row=0, column=0, columnspan=4, sticky='nsew')
+
+        babip_label = ctk.CTkLabel(self, text='BABIP')
+        babip_label.grid(column=0, row=2, sticky='nsew')
+
+        avoid_k_label = ctk.CTkLabel(self, text='AvK')
+        avoid_k_label.grid(column=0, row=3, sticky='nsew')
+
+        gap_label = ctk.CTkLabel(self, text='GAP')
+        gap_label.grid(column=0, row=4, sticky='nsew')
+
+        power_label = ctk.CTkLabel(self, text='Power')
+        power_label.grid(column=0, row=5, sticky='nsew')
+
+        eye_label = ctk.CTkLabel(self, text='Eye')
+        eye_label.grid(column=0, row=6, sticky='nsew')
+
+        # Top labels
+        overall_label = ctk.CTkLabel(self, text='OA')
+        overall_label.grid(column=1, row=1, sticky='nsew')
+
+        vs_left_label = ctk.CTkLabel(self, text='vsL')
+        vs_left_label.grid(column=2, row=1, sticky='nsew')
+
+        vs_right_label = ctk.CTkLabel(self, text='vsR')
+        vs_right_label.grid(column=3, row=1, sticky='nsew')
+
+        # User inputs for weights
+        babip_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.babip_overall_var,
+            width=25
+        )
+        babip_overall_input.grid(column=1, row=2, sticky='nsew')
+
+        babip_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.babip_v_left_var,
+            width=25
+        )
+        babip_v_left_input.grid(column=2, row=2, sticky='nsew')
+
+        babip_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.babip_v_right_var,
+            width=25
+        )
+        babip_v_right_input.grid(column=3, row=2, sticky='nsew')
+
+        avoid_k_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.avoid_k_overall_var,
+            width=25
+        )
+        avoid_k_overall_input.grid(column=1, row=3, sticky='nsew')
+
+        avoid_k_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.avoid_k_left_var,
+            width=25
+        )
+        avoid_k_left_input.grid(column=2, row=3, sticky='nsew')
+
+        avoid_k_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.avoid_k_right_var,
+            width=25
+        )
+        avoid_k_right_input.grid(column=3, row=3, sticky='nsew')
+
+        gap_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.gap_overall_var,
+            width=25
+        )
+        gap_overall_input.grid(column=1, row=4, sticky='nsew')
+
+        gap_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.gap_v_left_var,
+            width=25
+        )
+        gap_v_left_input.grid(column=2, row=4, sticky='nsew')
+
+        gap_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.gap_v_right_var,
+            width=25
+        )
+        gap_v_right_input.grid(column=3, row=4, sticky='nsew')
+
+        power_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.power_overall_var,
+            width=25
+        )
+        power_overall_input.grid(column=1, row=5, sticky='nsew')
+
+        power_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.power_v_left_var,
+            width=25
+        )
+        power_v_left_input.grid(column=2, row=5, sticky='nsew')
+
+        power_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.power_v_right_var,
+            width=25
+        )
+        power_v_right_input.grid(column=3, row=5, sticky='nsew')
+
+        eye_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.eye_overall_var,
+            width=25
+        )
+        eye_overall_input.grid(column=1, row=6, sticky='nsew')
+
+        eye_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.eye_v_left_var,
+            width=25
+        )
+        eye_v_left_input.grid(column=2, row=6, sticky='nsew')
+
+        eye_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.eye_v_right_var,
+            width=25
+        )
+        eye_v_right_input.grid(column=3, row=6, sticky='nsew')
+
+    def get_batting_weights(self):
+        """Get the weights from the inputs."""
+
+        weights = {}
+
+        def parse(var):
+            try:
+                return float(var.get())
+            except ValueError:
+                return 1
+
+        weights['BABIP'] = parse(self.babip_overall_var)
+        weights['BABIP vL'] = parse(self.babip_v_left_var)
+        weights['BABIP vR'] = parse(self.babip_v_right_var)
+        weights['Avoid Ks'] = parse(self.avoid_k_overall_var)
+        weights['Avoid K vL'] = parse(self.avoid_k_left_var)
+        weights['Avoid K vR'] = parse(self.avoid_k_right_var)
+        weights['Gap'] = parse(self.gap_overall_var)
+        weights['Gap vL'] = parse(self.gap_v_left_var)
+        weights['Gap vR'] = parse(self.gap_v_right_var)
+        weights['Power'] = parse(self.power_overall_var)
+        weights['Power vL'] = parse(self.power_v_left_var)
+        weights['Power vR'] = parse(self.power_v_right_var)
+        weights['Eye'] = parse(self.eye_overall_var)
+        weights['Eye vL'] = parse(self.eye_v_left_var)
+        weights['Eye vR'] = parse(self.eye_v_right_var)
+
+        return weights

--- a/utils/view_utils/batting_weights_frame.py
+++ b/utils/view_utils/batting_weights_frame.py
@@ -1,10 +1,12 @@
 """Custom frame for users to enter batting weights."""
 import customtkinter as ctk
 
+
 class BattingWeightsFrame(ctk.CTkFrame):
     """Frame for users to enter batting weights."""
 
     def __init__(self, parent):
+        """Frame for users to enter batting weights."""
         ctk.CTkFrame.__init__(self, parent)
 
         self.columnconfigure(0, weight=1)
@@ -28,7 +30,6 @@ class BattingWeightsFrame(ctk.CTkFrame):
         self.eye_overall_var = ctk.StringVar(value='1')
         self.eye_v_left_var = ctk.StringVar(value='1')
         self.eye_v_right_var = ctk.StringVar(value='1')
-
 
         # Left side labels
         frame_label = ctk.CTkLabel(self, text='Bat Weights')
@@ -167,7 +168,6 @@ class BattingWeightsFrame(ctk.CTkFrame):
 
     def get_batting_weights(self):
         """Get the weights from the inputs."""
-
         weights = {}
 
         def parse(var):

--- a/utils/view_utils/card_type_select_frame.py
+++ b/utils/view_utils/card_type_select_frame.py
@@ -7,6 +7,7 @@ class CardTypeSelectFrame(ctk.CTkFrame):
     """Custom class for card type selection."""
 
     def __init__(self, parent):
+        """Frame for selecting card type."""
         ctk.CTkFrame.__init__(self, parent)
 
         self.columnconfigure(0, weight=1)
@@ -49,7 +50,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        live_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        live_checkbox.grid(row=rating_num // 3,
+                           column=rating_num % 3,
+                           sticky='nsew'
+                           )
         rating_num += 1
 
         nl_checkbox = ctk.CTkCheckBox(
@@ -60,7 +64,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        nl_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        nl_checkbox.grid(row=rating_num // 3,
+                         column=rating_num % 3,
+                         sticky='nsew'
+                         )
         rating_num += 1
 
         rookie_checkbox = ctk.CTkCheckBox(
@@ -71,7 +78,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        rookie_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rookie_checkbox.grid(row=rating_num // 3,
+                             column=rating_num % 3,
+                             sticky='nsew'
+                             )
         rating_num += 1
 
         legend_checkbox = ctk.CTkCheckBox(
@@ -82,7 +92,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        legend_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        legend_checkbox.grid(row=rating_num // 3,
+                             column=rating_num % 3,
+                             sticky='nsew'
+                             )
         rating_num += 1
 
         allstar_checkbox = ctk.CTkCheckBox(
@@ -93,7 +106,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        allstar_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        allstar_checkbox.grid(row=rating_num // 3,
+                              column=rating_num % 3,
+                              sticky='nsew'
+                              )
         rating_num += 1
 
         future_checkbox = ctk.CTkCheckBox(
@@ -104,7 +120,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        future_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        future_checkbox.grid(row=rating_num // 3,
+                             column=rating_num % 3,
+                             sticky='nsew'
+                             )
         rating_num += 1
 
         snapshot_checkbox = ctk.CTkCheckBox(
@@ -115,7 +134,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        snapshot_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        snapshot_checkbox.grid(row=rating_num // 3,
+                               column=rating_num % 3,
+                               sticky='nsew'
+                               )
         rating_num += 1
 
         unsung_checkbox = ctk.CTkCheckBox(
@@ -126,7 +148,10 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        unsung_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        unsung_checkbox.grid(row=rating_num // 3,
+                             column=rating_num % 3,
+                             sticky='nsew'
+                             )
         rating_num += 1
 
         hardware_checkbox = ctk.CTkCheckBox(
@@ -137,10 +162,11 @@ class CardTypeSelectFrame(ctk.CTkFrame):
             offvalue=0,
             command=set_selected_card_types
         )
-        hardware_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        hardware_checkbox.grid(row=rating_num // 3,
+                               column=rating_num % 3,
+                               sticky='nsew'
+                               )
         rating_num += 1
-
-
 
     def get_selected_card_types(self):
         """Return the selected card types."""

--- a/utils/view_utils/card_type_select_frame.py
+++ b/utils/view_utils/card_type_select_frame.py
@@ -1,0 +1,147 @@
+"""Modular frame for selecting card type."""
+import customtkinter as ctk
+from customtkinter import CTkCheckBox
+
+
+class CardTypeSelectFrame(ctk.CTkFrame):
+    """Custom class for card type selection."""
+
+    def __init__(self, parent):
+        ctk.CTkFrame.__init__(self, parent)
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
+
+        self.card_types_to_select = []
+
+        # Variables
+
+        live_var = ctk.IntVar(value=1)
+        nl_var = ctk.IntVar(value=2)
+        rookie_var = ctk.IntVar(value=3)
+        legend_var = ctk.IntVar(value=4)
+        allstar_var = ctk.IntVar(value=5)
+        fl_var = ctk.IntVar(value=6)
+        snapshot_var = ctk.IntVar(value=7)
+        unsung_var = ctk.IntVar(value=8)
+        hardware_var = ctk.IntVar(value=9)
+
+        frame_label = ctk.CTkLabel(self, text='Select Card Type')
+        frame_label.grid(row=0, column=0, columnspan=3, sticky='nsew')
+
+        def set_selected_card_types():
+            """Set the list of selected card types."""
+            self.card_types_to_select.clear()
+            all_checkboxes = self.winfo_children()
+            for checkbox_select in all_checkboxes:
+                if isinstance(checkbox_select, CTkCheckBox):
+                    if checkbox_select.get() != 0:
+                        self.card_types_to_select.append(checkbox_select.get())
+
+        rating_num = 0
+
+        live_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Live',
+            variable=live_var,
+            onvalue=1,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        live_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        nl_checkbox = ctk.CTkCheckBox(
+            self,
+            text='NL',
+            variable=nl_var,
+            onvalue=2,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        nl_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        rookie_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Rookie',
+            variable=rookie_var,
+            onvalue=3,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        rookie_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        legend_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Legend',
+            variable=legend_var,
+            onvalue=4,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        legend_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        allstar_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Allstar',
+            variable=allstar_var,
+            onvalue=5,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        allstar_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        future_checkbox = ctk.CTkCheckBox(
+            self,
+            text='FL',
+            variable=fl_var,
+            onvalue=6,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        future_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        snapshot_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Snapshot',
+            variable=snapshot_var,
+            onvalue=7,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        snapshot_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        unsung_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Unsung',
+            variable=unsung_var,
+            onvalue=8,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        unsung_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+        hardware_checkbox = ctk.CTkCheckBox(
+            self,
+            text='Hardware',
+            variable=hardware_var,
+            onvalue=9,
+            offvalue=0,
+            command=set_selected_card_types
+        )
+        hardware_checkbox.grid(row=rating_num // 3, column=rating_num % 3, sticky='nsew')
+        rating_num += 1
+
+
+
+    def get_selected_card_types(self):
+        """Return the selected card types."""
+        return self.card_types_to_select

--- a/utils/view_utils/card_value_select_frame.py
+++ b/utils/view_utils/card_value_select_frame.py
@@ -7,17 +7,28 @@ class CardValueSelectFrame(ctk.CTkFrame):
 
     def __init__(self, parent):
         """Initialize the frame."""
-        ctk.CTkFrame.__init__(self, parent)
+        ctk.CTkFrame.__init__(self, parent, border_color='gray', border_width=2)
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
+        self.columnconfigure(3, weight=1)
 
         self.min_val = ctk.StringVar(self, value='40')
         self.max_val = ctk.StringVar(self, value='105')
+
+        self.frame_label = ctk.CTkLabel(
+            self,
+            text='Card Values'
+        )
+        self.frame_label.grid(row=0, column=0, columnspan=4,sticky='nsew')
 
         self.min_value_label = ctk.CTkLabel(
             self,
             text="Min"
         )
         self.min_value_label.grid(
-            row=0,
+            row=1,
             column=0,
             padx=5,
             pady=5
@@ -30,7 +41,7 @@ class CardValueSelectFrame(ctk.CTkFrame):
             width=45,
         )
         self.min_value_input.grid(
-            row=0,
+            row=1,
             column=1,
             padx=5,
             pady=5
@@ -41,7 +52,7 @@ class CardValueSelectFrame(ctk.CTkFrame):
             text="Max",
         )
         self.max_value_label.grid(
-            row=0,
+            row=1,
             column=2,
             padx=5,
             pady=5
@@ -54,7 +65,7 @@ class CardValueSelectFrame(ctk.CTkFrame):
             width=45
         )
         self.max_value_input.grid(
-            row=0,
+            row=1,
             column=3,
             padx=5,
             pady=5

--- a/utils/view_utils/card_value_select_frame.py
+++ b/utils/view_utils/card_value_select_frame.py
@@ -14,7 +14,7 @@ class CardValueSelectFrame(ctk.CTkFrame):
 
         self.min_value_label = ctk.CTkLabel(
             self,
-            text="Min Value"
+            text="Min"
         )
         self.min_value_label.grid(
             row=0,
@@ -26,7 +26,8 @@ class CardValueSelectFrame(ctk.CTkFrame):
         self.min_value_input = ctk.CTkEntry(
             self,
             textvariable=self.min_val,
-            placeholder_text='40'
+            placeholder_text='40',
+            width=45,
         )
         self.min_value_input.grid(
             row=0,
@@ -37,11 +38,11 @@ class CardValueSelectFrame(ctk.CTkFrame):
 
         self.max_value_label = ctk.CTkLabel(
             self,
-            text="Max Value"
+            text="Max",
         )
         self.max_value_label.grid(
-            row=1,
-            column=0,
+            row=0,
+            column=2,
             padx=5,
             pady=5
         )
@@ -49,11 +50,12 @@ class CardValueSelectFrame(ctk.CTkFrame):
         self.max_value_input = ctk.CTkEntry(
             self,
             textvariable=self.max_val,
-            placeholder_text='105'
+            placeholder_text='105',
+            width=45
         )
         self.max_value_input.grid(
-            row=1,
-            column=1,
+            row=0,
+            column=3,
             padx=5,
             pady=5
         )

--- a/utils/view_utils/card_value_select_frame.py
+++ b/utils/view_utils/card_value_select_frame.py
@@ -7,7 +7,10 @@ class CardValueSelectFrame(ctk.CTkFrame):
 
     def __init__(self, parent):
         """Initialize the frame."""
-        ctk.CTkFrame.__init__(self, parent, border_color='gray', border_width=2)
+        ctk.CTkFrame.__init__(self, parent,
+                              border_color='gray',
+                              border_width=2
+                              )
 
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
@@ -21,7 +24,7 @@ class CardValueSelectFrame(ctk.CTkFrame):
             self,
             text='Card Values'
         )
-        self.frame_label.grid(row=0, column=0, columnspan=4,sticky='nsew')
+        self.frame_label.grid(row=0, column=0, columnspan=4, sticky='nsew')
 
         self.min_value_label = ctk.CTkLabel(
             self,

--- a/utils/view_utils/defense_weights_frame.py
+++ b/utils/view_utils/defense_weights_frame.py
@@ -1,0 +1,190 @@
+"""Frame for user to set defense weights."""
+import customtkinter as ctk
+
+
+class DefenseWeightsFrame(ctk.CTkFrame):
+    """Frame class for defense weights."""
+    def __init__(self, parent):
+        ctk.CTkFrame.__init__(self, parent)
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
+        self.columnconfigure(3, weight=1)
+        self.columnconfigure(4, weight=1)
+
+        # Variables
+        self.catch_abil_var = ctk.StringVar(value='1')
+        self.catch_frame_var = ctk.StringVar(value='1')
+        self.catch_arm_var = ctk.StringVar(value='1')
+        self.infield_range_var = ctk.StringVar(value='1')
+        self.infield_error_var = ctk.StringVar(value='1')
+        self.infield_arm_var = ctk.StringVar(value='1')
+        self.infield_dp_var = ctk.StringVar(value='1')
+        self.outfield_range_var = ctk.StringVar(value='1')
+        self.outfield_error_var = ctk.StringVar(value='1')
+        self.outfield_arm_var = ctk.StringVar(value='1')
+
+
+        # Frame label
+        self.frame_label = ctk.CTkLabel(
+            self,
+            text="Defense Weights",
+        )
+        self.frame_label.grid(row=0, column=0, columnspan=5, sticky='nsew')
+
+        # Side labels
+        self.catcher_label = ctk.CTkLabel(
+            self,
+            text='Catcher'
+        )
+        self.catcher_label.grid(row=2, column=0, sticky='nsew')
+
+        self.infield_label = ctk.CTkLabel(
+            self,
+            text='IF'
+        )
+        self.infield_label.grid(row=4, column=0, sticky='nsew')
+
+        self.outfield_label = ctk.CTkLabel(
+            self,
+            text='OF'
+        )
+        self.outfield_label.grid(row=5, column=0, sticky='nsew')
+
+        # Top labels
+        self.catcher_abil_label = ctk.CTkLabel(
+            self,
+            text='Abil'
+        )
+        self.catcher_abil_label.grid(row=1, column=1, sticky='nsew')
+
+        self.catcher_frame_label = ctk.CTkLabel(
+            self,
+            text='Frame'
+        )
+        self.catcher_frame_label.grid(row=1, column=2, sticky='nsew')
+
+        self.catch_arm_label = ctk.CTkLabel(
+            self,
+            text='Arm'
+        )
+        self.catch_arm_label.grid(row=1, column=3, sticky='nsew')
+
+        self.range_label = ctk.CTkLabel(
+            self,
+            text='Range'
+        )
+        self.range_label.grid(row=3, column=1, sticky='nsew')
+
+        self.error_label = ctk.CTkLabel(
+            self,
+            text='Error'
+        )
+        self.error_label.grid(row=3, column=2, sticky='nsew')
+
+        self.arm_label = ctk.CTkLabel(
+            self,
+            text='Arm'
+        )
+        self.arm_label.grid(row=3, column=3, sticky='nsew')
+
+        self.turn_dp_label = ctk.CTkLabel(
+            self,
+            text='DP'
+        )
+        self.turn_dp_label.grid(row=3, column=4, sticky='nsew')
+
+
+        # Input boxes
+        self.catcher_abil_input = ctk.CTkEntry(
+            self,
+            textvariable=self.catch_abil_var,
+            width=25
+        )
+        self.catcher_abil_input.grid(row=2, column=1, sticky='nsew')
+
+        self.catch_frame_input = ctk.CTkEntry(
+            self,
+            textvariable=self.catch_frame_var,
+            width=25
+        )
+        self.catch_frame_input.grid(row=2, column=2, sticky='nsew')
+
+        self.catcher_arm_input = ctk.CTkEntry(
+            self,
+            textvariable=self.catch_arm_var,
+            width=25
+        )
+        self.catcher_arm_input.grid(row=2, column=3, sticky='nsew')
+
+        self.infield_range_input = ctk.CTkEntry(
+            self,
+            textvariable=self.infield_range_var,
+            width=25
+        )
+        self.infield_range_input.grid(row=4, column=1, sticky='nsew')
+
+        self.infield_error_input = ctk.CTkEntry(
+            self,
+            textvariable=self.infield_error_var,
+            width=25
+        )
+        self.infield_error_input.grid(row=4, column=2, sticky='nsew')
+
+        self.infield_arm_input = ctk.CTkEntry(
+            self,
+            textvariable=self.infield_arm_var,
+            width=25
+        )
+        self.infield_arm_input.grid(row=4, column=3, sticky='nsew')
+
+        self.turn_dp_input = ctk.CTkEntry(
+            self,
+            textvariable=self.infield_dp_var,
+            width=25
+        )
+        self.turn_dp_input.grid(row=4, column=4, sticky='nsew')
+
+        self.outfield_range_input = ctk.CTkEntry(
+            self,
+            textvariable=self.outfield_range_var,
+            width=25
+        )
+        self.outfield_range_input.grid(row=5, column=1, sticky='nsew')
+
+        self.outfield_error_input = ctk.CTkEntry(
+            self,
+            textvariable=self.outfield_error_var,
+            width=25
+        )
+        self.outfield_error_input.grid(row=5, column=2, sticky='nsew')
+
+        self.outfield_arm_input = ctk.CTkEntry(
+            self,
+            textvariable=self.outfield_arm_var,
+            width=25
+        )
+        self.outfield_arm_input.grid(row=5, column=3, sticky='nsew')
+
+    def get_defense_weights(self):
+        defense_weights = {}
+
+        def parse(var):
+            try:
+                return float(var.get())
+            except ValueError:
+                return 1
+
+        defense_weights['CatchAbil'] = parse(self.catch_abil_var)
+        defense_weights['CatchFrame'] = parse(self.catch_frame_var)
+        defense_weights['CatchArm'] = parse(self.catch_arm_var)
+        defense_weights['IF Range'] = parse(self.infield_range_var)
+        defense_weights['IF Error'] = parse(self.infield_error_var)
+        defense_weights['IF Arm'] = parse(self.infield_arm_var)
+        defense_weights['DP'] = parse(self.infield_dp_var)
+        defense_weights['OF Range'] = parse(self.outfield_range_var)
+        defense_weights['OF Error'] = parse(self.outfield_error_var)
+        defense_weights['OF Arm'] = parse(self.outfield_arm_var)
+
+        return defense_weights

--- a/utils/view_utils/defense_weights_frame.py
+++ b/utils/view_utils/defense_weights_frame.py
@@ -4,7 +4,9 @@ import customtkinter as ctk
 
 class DefenseWeightsFrame(ctk.CTkFrame):
     """Frame class for defense weights."""
+
     def __init__(self, parent):
+        """Initialize the frame."""
         ctk.CTkFrame.__init__(self, parent)
 
         self.columnconfigure(0, weight=1)
@@ -24,7 +26,6 @@ class DefenseWeightsFrame(ctk.CTkFrame):
         self.outfield_range_var = ctk.StringVar(value='1')
         self.outfield_error_var = ctk.StringVar(value='1')
         self.outfield_arm_var = ctk.StringVar(value='1')
-
 
         # Frame label
         self.frame_label = ctk.CTkLabel(
@@ -94,7 +95,6 @@ class DefenseWeightsFrame(ctk.CTkFrame):
             text='DP'
         )
         self.turn_dp_label.grid(row=3, column=4, sticky='nsew')
-
 
         # Input boxes
         self.catcher_abil_input = ctk.CTkEntry(
@@ -168,6 +168,7 @@ class DefenseWeightsFrame(ctk.CTkFrame):
         self.outfield_arm_input.grid(row=5, column=3, sticky='nsew')
 
     def get_defense_weights(self):
+        """Get the weights for defense used in other scripts."""
         defense_weights = {}
 
         def parse(var):

--- a/utils/view_utils/general_stat_select_frame.py
+++ b/utils/view_utils/general_stat_select_frame.py
@@ -6,6 +6,7 @@ class GeneralStatSelectFrame(ctk.CTkFrame):
     """Frame for selecting general stat options to show."""
 
     def __init__(self, parent):
+        """Frame for selecting general stat options to show."""
         super().__init__(parent)
 
         available_general_stats = ['owned', 'L10', 'L10V']
@@ -35,14 +36,15 @@ class GeneralStatSelectFrame(ctk.CTkFrame):
                 command=set_selected_general_stats
             )
             checkbox.grid(
-                row = stat_num // 3,
-                column = stat_num % 3,
-                padx = 3,
-                pady = 3,
-                sticky = 'nsew'
+                row=stat_num // 3,
+                column=stat_num % 3,
+                padx=3,
+                pady=3,
+                sticky='nsew'
             )
             self.checkbox_vars[stat] = var
             stat_num += 1
 
     def get_selected_general_stats(self):
+        """Return the selected general stats."""
         return self.general_stats_to_keep

--- a/utils/view_utils/pitcher_weights_frame.py
+++ b/utils/view_utils/pitcher_weights_frame.py
@@ -6,6 +6,7 @@ class PitcherWeightsFrame(ctk.CTkFrame):
     """Custom frame for pitcher weights."""
 
     def __init__(self, parent):
+        """Frame for setting pitcher rating weights."""
         super().__init__(parent)
 
         self.columnconfigure(0, weight=1)
@@ -163,8 +164,8 @@ class PitcherWeightsFrame(ctk.CTkFrame):
         )
         self.control_v_right_input.grid(row=5, column=3, sticky='nsew')
 
-
     def get_pitching_weights(self):
+        """Return the selected pitching weights."""
         weights = {}
 
         def parse(var):

--- a/utils/view_utils/pitcher_weights_frame.py
+++ b/utils/view_utils/pitcher_weights_frame.py
@@ -1,0 +1,189 @@
+"""Frame for setting pitcher rating weights."""
+import customtkinter as ctk
+
+
+class PitcherWeightsFrame(ctk.CTkFrame):
+    """Custom frame for pitcher weights."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
+        self.columnconfigure(3, weight=1)
+
+        # Variables
+        self.stuff_oa_var = ctk.StringVar(value='1')
+        self.stuff_v_left_var = ctk.StringVar(value='1')
+        self.stuff_v_right_var = ctk.StringVar(value='1')
+        self.phr_oa_var = ctk.StringVar(value='1')
+        self.phr_v_left_var = ctk.StringVar(value='1')
+        self.phr_v_right_var = ctk.StringVar(value='1')
+        self.pbabip_oa_var = ctk.StringVar(value='1')
+        self.pbabip_v_left_var = ctk.StringVar(value='1')
+        self.pbabip_v_right_var = ctk.StringVar(value='1')
+        self.control_oa_var = ctk.StringVar(value='1')
+        self.control_v_left_var = ctk.StringVar(value='1')
+        self.control_v_right_var = ctk.StringVar(value='1')
+
+        # Top label
+        self.frame_label = ctk.CTkLabel(
+            self,
+            text='Pitcher Weights',
+        )
+        self.frame_label.grid(row=0, column=0, columnspan=4, sticky='nsew')
+
+        # Left side labels
+        self.stuff_label = ctk.CTkLabel(
+            self,
+            text='Stuff'
+        )
+        self.stuff_label.grid(row=2, column=0, sticky='nsew')
+
+        self.phr_label = ctk.CTkLabel(
+            self,
+            text='pHR'
+        )
+        self.phr_label.grid(row=3, column=0, sticky='nsew')
+
+        self.pbabip_label = ctk.CTkLabel(
+            self,
+            text='pBABIP'
+        )
+        self.pbabip_label.grid(row=4, column=0, sticky='nsew')
+
+        self.control_label = ctk.CTkLabel(
+            self,
+            text='Control'
+        )
+        self.control_label.grid(row=5, column=0, sticky='nsew')
+
+        # Top labels
+        self.overall_label = ctk.CTkLabel(
+            self,
+            text='OA'
+        )
+        self.overall_label.grid(row=1, column=1, sticky='nsew')
+
+        self.v_left_label = ctk.CTkLabel(
+            self,
+            text='vL'
+        )
+        self.v_left_label.grid(row=1, column=2, sticky='nsew')
+
+        self.v_right_label = ctk.CTkLabel(
+            self,
+            text='vR'
+        )
+        self.v_right_label.grid(row=1, column=3, sticky='nsew')
+
+        # Input boxes
+        self.stuff_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.stuff_oa_var,
+            width=25
+        )
+        self.stuff_overall_input.grid(row=2, column=1, sticky='nsew')
+
+        self.stuff_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.stuff_v_left_var,
+            width=25
+        )
+        self.stuff_v_left_input.grid(row=2, column=2, sticky='nsew')
+
+        self.stuff_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.stuff_v_right_var,
+            width=25
+        )
+        self.stuff_v_right_input.grid(row=2, column=3, sticky='nsew')
+
+        self.phr_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.phr_oa_var,
+            width=25
+        )
+        self.phr_overall_input.grid(row=3, column=1, sticky='nsew')
+
+        self.phr_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.phr_v_left_var,
+            width=25
+        )
+        self.phr_v_left_input.grid(row=3, column=2, sticky='nsew')
+
+        self.phr_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.phr_v_right_var,
+            width=25
+        )
+        self.phr_v_right_input.grid(row=3, column=3, sticky='nsew')
+
+        self.pbabip_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.pbabip_oa_var,
+            width=25
+        )
+        self.pbabip_overall_input.grid(row=4, column=1, sticky='nsew')
+
+        self.pbabip_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.pbabip_v_left_var,
+            width=25
+        )
+        self.pbabip_v_left_input.grid(row=4, column=2, sticky='nsew')
+
+        self.pbabip_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.pbabip_v_right_var,
+            width=25
+        )
+        self.pbabip_v_right_input.grid(row=4, column=3, sticky='nsew')
+
+        self.control_overall_input = ctk.CTkEntry(
+            self,
+            textvariable=self.control_oa_var,
+            width=25
+        )
+        self.control_overall_input.grid(row=5, column=1, sticky='nsew')
+
+        self.control_v_left_input = ctk.CTkEntry(
+            self,
+            textvariable=self.control_v_left_var,
+            width=25
+        )
+        self.control_v_left_input.grid(row=5, column=2, sticky='nsew')
+
+        self.control_v_right_input = ctk.CTkEntry(
+            self,
+            textvariable=self.control_v_right_var,
+            width=25
+        )
+        self.control_v_right_input.grid(row=5, column=3, sticky='nsew')
+
+
+    def get_pitching_weights(self):
+        weights = {}
+
+        def parse(var):
+            try:
+                return float(var.get())
+            except ValueError:
+                return 1
+
+        weights['Stuff'] = parse(self.stuff_oa_var)
+        weights['Stuff vL'] = parse(self.stuff_v_left_var)
+        weights['Stuff vR'] = parse(self.stuff_v_right_var)
+        weights['pHR'] = parse(self.phr_oa_var)
+        weights['pHR vL'] = parse(self.phr_v_left_var)
+        weights['pHR vR'] = parse(self.phr_v_right_var)
+        weights['pBABIP'] = parse(self.pbabip_oa_var)
+        weights['pBABIP vL'] = parse(self.pbabip_v_left_var)
+        weights['pBABIP vR'] = parse(self.pbabip_v_right_var)
+        weights['Control'] = parse(self.control_oa_var)
+        weights['Control vL'] = parse(self.control_v_left_var)
+        weights['Control vR'] = parse(self.control_v_right_var)
+
+        return weights

--- a/utils/view_utils/position_select_frame.py
+++ b/utils/view_utils/position_select_frame.py
@@ -1,0 +1,43 @@
+"""Frame for selecting which position to view."""
+import customtkinter as ctk
+
+
+class PositionSelectFrame(ctk.CTkFrame):
+    def __init__(self, parent):
+        ctk.CTkFrame.__init__(self, parent)
+
+        self.selected_position = ctk.StringVar(value='')
+
+        self.catcher_radio = ctk.CTkRadioButton(self, text='C', variable=self.selected_position, value='LearnC')
+        self.catcher_radio.grid(row=0, column=0, sticky='nsew')
+
+        self.first_base_radio = ctk.CTkRadioButton(self, text='1B', variable=self.selected_position, value='Learn1B')
+        self.first_base_radio.grid(row=0, column=1, sticky='nsew')
+
+        self.second_base_radio = ctk.CTkRadioButton(self, text='2B', variable=self.selected_position, value='Learn2B')
+        self.second_base_radio.grid(row=0, column=2, sticky='nsew')
+
+        self.third_base_radio = ctk.CTkRadioButton(self, text='3B', variable=self.selected_position, value='Learn3B')
+        self.third_base_radio.grid(row=1, column=0, sticky='nsew')
+
+        self.shortstop_radio = ctk.CTkRadioButton(self, text='SS', variable=self.selected_position, value='LearnSS')
+        self.shortstop_radio.grid(row=1, column=1, sticky='nsew')
+
+        self.left_field_radio = ctk.CTkRadioButton(self, text='LF', variable=self.selected_position, value='LearnLF')
+        self.left_field_radio.grid(row=1, column=2, sticky='nsew')
+
+        self.center_field_radio = ctk.CTkRadioButton(self, text='CF', variable=self.selected_position, value='LearnCF')
+        self.center_field_radio.grid(row=2, column=0, sticky='nsew')
+
+        self.right_field_radio = ctk.CTkRadioButton(self, text='RF', variable=self.selected_position, value='LearnRF')
+        self.right_field_radio.grid(row=2, column=1, sticky='nsew')
+
+        self.batters_radio = ctk.CTkRadioButton(self, text='Bats', variable=self.selected_position, value='Batters')
+        self.batters_radio.grid(row=2, column=2, sticky='nsew')
+
+        self.pitchers_radio = ctk.CTkRadioButton(self, text='P', variable=self.selected_position, value='LearnP')
+        self.pitchers_radio.grid(row=3, column=1, sticky='nsew')
+
+
+    def get_selected_position(self):
+        return self.selected_position.get()

--- a/utils/view_utils/position_select_frame.py
+++ b/utils/view_utils/position_select_frame.py
@@ -3,41 +3,94 @@ import customtkinter as ctk
 
 
 class PositionSelectFrame(ctk.CTkFrame):
+    """Frame for selecting which position to view."""
+
     def __init__(self, parent):
+        """Frame for selecting which position to view."""
         ctk.CTkFrame.__init__(self, parent)
 
         self.selected_position = ctk.StringVar(value='')
 
-        self.catcher_radio = ctk.CTkRadioButton(self, text='C', variable=self.selected_position, value='LearnC')
+        self.catcher_radio = ctk.CTkRadioButton(
+            self,
+            text='C',
+            variable=self.selected_position,
+            value='LearnC'
+        )
         self.catcher_radio.grid(row=0, column=0, sticky='nsew')
 
-        self.first_base_radio = ctk.CTkRadioButton(self, text='1B', variable=self.selected_position, value='Learn1B')
+        self.first_base_radio = ctk.CTkRadioButton(
+            self,
+            text='1B',
+            variable=self.selected_position,
+            value='Learn1B'
+        )
         self.first_base_radio.grid(row=0, column=1, sticky='nsew')
 
-        self.second_base_radio = ctk.CTkRadioButton(self, text='2B', variable=self.selected_position, value='Learn2B')
+        self.second_base_radio = ctk.CTkRadioButton(
+            self,
+            text='2B',
+            variable=self.selected_position,
+            value='Learn2B'
+        )
         self.second_base_radio.grid(row=0, column=2, sticky='nsew')
 
-        self.third_base_radio = ctk.CTkRadioButton(self, text='3B', variable=self.selected_position, value='Learn3B')
+        self.third_base_radio = ctk.CTkRadioButton(
+            self,
+            text='3B',
+            variable=self.selected_position,
+            value='Learn3B'
+        )
         self.third_base_radio.grid(row=1, column=0, sticky='nsew')
 
-        self.shortstop_radio = ctk.CTkRadioButton(self, text='SS', variable=self.selected_position, value='LearnSS')
+        self.shortstop_radio = ctk.CTkRadioButton(
+            self,
+            text='SS',
+            variable=self.selected_position,
+            value='LearnSS'
+        )
         self.shortstop_radio.grid(row=1, column=1, sticky='nsew')
 
-        self.left_field_radio = ctk.CTkRadioButton(self, text='LF', variable=self.selected_position, value='LearnLF')
+        self.left_field_radio = ctk.CTkRadioButton(
+            self,
+            text='LF',
+            variable=self.selected_position,
+            value='LearnLF'
+                  '')
         self.left_field_radio.grid(row=1, column=2, sticky='nsew')
 
-        self.center_field_radio = ctk.CTkRadioButton(self, text='CF', variable=self.selected_position, value='LearnCF')
+        self.center_field_radio = ctk.CTkRadioButton(
+            self,
+            text='CF',
+            variable=self.selected_position,
+            value='LearnCF'
+        )
         self.center_field_radio.grid(row=2, column=0, sticky='nsew')
 
-        self.right_field_radio = ctk.CTkRadioButton(self, text='RF', variable=self.selected_position, value='LearnRF')
+        self.right_field_radio = ctk.CTkRadioButton(
+            self,
+            text='RF',
+            variable=self.selected_position,
+            value='LearnRF'
+        )
         self.right_field_radio.grid(row=2, column=1, sticky='nsew')
 
-        self.batters_radio = ctk.CTkRadioButton(self, text='Bats', variable=self.selected_position, value='Batters')
+        self.batters_radio = ctk.CTkRadioButton(
+            self,
+            text='Bats',
+            variable=self.selected_position,
+            value='Batters'
+        )
         self.batters_radio.grid(row=2, column=2, sticky='nsew')
 
-        self.pitchers_radio = ctk.CTkRadioButton(self, text='P', variable=self.selected_position, value='LearnP')
+        self.pitchers_radio = ctk.CTkRadioButton(
+            self,
+            text='P',
+            variable=self.selected_position,
+            value='LearnP'
+        )
         self.pitchers_radio.grid(row=3, column=1, sticky='nsew')
 
-
     def get_selected_position(self):
+        """Return the selected position."""
         return self.selected_position.get()

--- a/utils/view_utils/ratings_menu_frame.py
+++ b/utils/view_utils/ratings_menu_frame.py
@@ -1,5 +1,4 @@
 """Menu for selecting which ratings to view and their weights."""
-from tkinter import BooleanVar
 from utils.view_utils.batting_weights_frame import BattingWeightsFrame
 from utils.view_utils.defense_weights_frame import DefenseWeightsFrame
 from utils.view_utils.pitcher_weights_frame import PitcherWeightsFrame
@@ -9,23 +8,26 @@ from utils.view_utils.position_select_frame import PositionSelectFrame
 from utils.view_utils.card_type_select_frame import CardTypeSelectFrame
 import customtkinter as ctk
 
+
 class RatingsMenuFrame(ctk.CTkFrame):
     """Frame for getting needed information from user."""
+
     def __init__(self, parent):
+        """Frame for getting needed information from user."""
         ctk.CTkFrame.__init__(self, parent)
 
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
         self.columnconfigure(2, weight=1)
         # Set up check boxes
-        available_ratings = ['BatOA', 'BatvL', 'BatvR', 'BSplit', 'BSR', 'Catch Def',
-                             'IF Def', 'OF Def', 'PitOA', 'PitvL', 'PitvR', 'PSplit', 'date']
+        available_ratings = ['BatOA', 'BatvL', 'BatvR', 'BSplit', 'BSR',
+                             'Catch Def', 'IF Def', 'OF Def', 'PitOA',
+                             'PitvL', 'PitvR', 'PSplit', 'date']
 
         self.ratings_to_keep = []
 
         def set_active_ratings():
             self.ratings_to_keep.clear()
-            all_checkboxes = self.winfo_children()
             for widget in self.winfo_children():
                 if isinstance(widget, ctk.CTkCheckBox):
                     if widget.get() != 'off':
@@ -136,7 +138,6 @@ class RatingsMenuFrame(ctk.CTkFrame):
         )
         row += 1
 
-
     def get_active_ratings(self):
         """Return the selected ratings to view."""
         return self.ratings_to_keep
@@ -147,10 +148,12 @@ class RatingsMenuFrame(ctk.CTkFrame):
         return batting_weights
 
     def get_pitching_weights(self):
+        """Get the weights for pitching."""
         pitching_weights = self.pitcher_weights_frame.get_pitching_weights()
         return pitching_weights
 
     def get_defense_weights(self):
+        """Get defense weights."""
         defense_weights = self.defense_weights_frame.get_defense_weights()
         return defense_weights
 
@@ -171,5 +174,7 @@ class RatingsMenuFrame(ctk.CTkFrame):
 
     def get_selected_card_type(self):
         """Return the selected card_type for batting."""
-        selected_card_types = self.card_type_select_frame.get_selected_card_types()
+        selected_card_types = (
+            self.card_type_select_frame.get_selected_card_types()
+        )
         return selected_card_types

--- a/utils/view_utils/ratings_menu_frame.py
+++ b/utils/view_utils/ratings_menu_frame.py
@@ -1,0 +1,116 @@
+"""Menu for selecting which ratings to view and their weights."""
+from tkinter import BooleanVar
+from utils.view_utils.batting_weights_frame import BattingWeightsFrame
+from utils.view_utils.defense_weights_frame import DefenseWeightsFrame
+from utils.view_utils.pitcher_weights_frame import PitcherWeightsFrame
+from utils.view_utils.card_value_select_frame import CardValueSelectFrame
+import customtkinter as ctk
+
+class RatingsMenuFrame(ctk.CTkFrame):
+    """Frame for getting needed information from user."""
+    def __init__(self, parent):
+        ctk.CTkFrame.__init__(self, parent)
+
+        # Set up check boxes
+        available_ratings = ['BatOA', 'BatvL', 'BatvR', 'BSR', 'Catch Def',
+                             'IF Def', 'OF Def', 'PitOA', 'PitvL', 'PitvR']
+
+        self.ratings_to_keep = []
+
+        def set_active_ratings():
+            self.ratings_to_keep.clear()
+            all_checkboxes = self.winfo_children()
+            for widget in self.winfo_children():
+                if isinstance(widget, ctk.CTkCheckBox):
+                    if widget.get() != 'off':
+                        self.ratings_to_keep.append(widget.get())
+
+        self.set_active_ratings = set_active_ratings
+
+        stat_num = 0
+        for rating in available_ratings:
+            var = BooleanVar(value=True)
+            checkbox = ctk.CTkCheckBox(
+                master=self,
+                text=rating,
+                onvalue=rating,
+                offvalue='off',
+                command=set_active_ratings
+            )
+            checkbox.grid(
+                column=stat_num % 3,
+                row=stat_num // 3,
+                sticky='nsew'
+            )
+
+            stat_num += 1
+
+        row = stat_num // 3 + 1
+
+        self.batter_weights_frame = BattingWeightsFrame(
+            self
+        )
+        self.batter_weights_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            sticky='nsew'
+        )
+        row += 1
+
+        self.pitcher_weights_frame = PitcherWeightsFrame(
+            self
+        )
+        self.pitcher_weights_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            sticky='nsew'
+        )
+        row += 1
+
+        self.defense_weights_frame = DefenseWeightsFrame(
+            self
+        )
+        self.defense_weights_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            sticky='nsew'
+        )
+        row += 1
+
+        self.card_value_frame = CardValueSelectFrame(
+            self
+        )
+        self.card_value_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            sticky='nsew'
+        )
+        row += 1
+
+
+
+    def get_active_ratings(self):
+        """Return the selected ratings to view."""
+        return self.ratings_to_keep
+
+    def get_batting_weights(self):
+        """Get the weights for batting."""
+        batting_weights = self.batter_weights_frame.get_batting_weights()
+        return batting_weights
+
+    def get_pitching_weights(self):
+        pitching_weights = self.pitcher_weights_frame.get_pitching_weights()
+        return pitching_weights
+
+    def get_defense_weights(self):
+        defense_weights = self.defense_weights_frame.get_defense_weights()
+        return defense_weights
+
+    def get_min_max_values(self):
+        """Return the min and max values for batting."""
+        min_value, max_value = self.card_value_frame.get_min_max_values()
+        return min_value, max_value

--- a/utils/view_utils/ratings_menu_frame.py
+++ b/utils/view_utils/ratings_menu_frame.py
@@ -4,6 +4,9 @@ from utils.view_utils.batting_weights_frame import BattingWeightsFrame
 from utils.view_utils.defense_weights_frame import DefenseWeightsFrame
 from utils.view_utils.pitcher_weights_frame import PitcherWeightsFrame
 from utils.view_utils.card_value_select_frame import CardValueSelectFrame
+from utils.view_utils.year_value_select_frame import YearValueSelectFrame
+from utils.view_utils.position_select_frame import PositionSelectFrame
+from utils.view_utils.card_type_select_frame import CardTypeSelectFrame
 import customtkinter as ctk
 
 class RatingsMenuFrame(ctk.CTkFrame):
@@ -11,9 +14,12 @@ class RatingsMenuFrame(ctk.CTkFrame):
     def __init__(self, parent):
         ctk.CTkFrame.__init__(self, parent)
 
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
         # Set up check boxes
-        available_ratings = ['BatOA', 'BatvL', 'BatvR', 'BSR', 'Catch Def',
-                             'IF Def', 'OF Def', 'PitOA', 'PitvL', 'PitvR']
+        available_ratings = ['BatOA', 'BatvL', 'BatvR', 'BSplit', 'BSR', 'Catch Def',
+                             'IF Def', 'OF Def', 'PitOA', 'PitvL', 'PitvR', 'PSplit', 'date']
 
         self.ratings_to_keep = []
 
@@ -29,7 +35,6 @@ class RatingsMenuFrame(ctk.CTkFrame):
 
         stat_num = 0
         for rating in available_ratings:
-            var = BooleanVar(value=True)
             checkbox = ctk.CTkCheckBox(
                 master=self,
                 text=rating,
@@ -54,6 +59,7 @@ class RatingsMenuFrame(ctk.CTkFrame):
             row=row,
             column=0,
             columnspan=3,
+            pady=5,
             sticky='nsew'
         )
         row += 1
@@ -65,6 +71,7 @@ class RatingsMenuFrame(ctk.CTkFrame):
             row=row,
             column=0,
             columnspan=3,
+            pady=5,
             sticky='nsew'
         )
         row += 1
@@ -76,6 +83,7 @@ class RatingsMenuFrame(ctk.CTkFrame):
             row=row,
             column=0,
             columnspan=3,
+            pady=5,
             sticky='nsew'
         )
         row += 1
@@ -87,10 +95,46 @@ class RatingsMenuFrame(ctk.CTkFrame):
             row=row,
             column=0,
             columnspan=3,
+            pady=5,
             sticky='nsew'
         )
         row += 1
 
+        self.year_select_frame = YearValueSelectFrame(
+            self,
+        )
+        self.year_select_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            pady=5,
+            sticky='nsew'
+        )
+        row += 1
+
+        self.position_select_frame = PositionSelectFrame(
+            self,
+        )
+        self.position_select_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            pady=5,
+            sticky='nsew'
+        )
+        row += 1
+
+        self.card_type_select_frame = CardTypeSelectFrame(
+            self
+        )
+        self.card_type_select_frame.grid(
+            row=row,
+            column=0,
+            columnspan=3,
+            pady=5,
+            sticky='nsew'
+        )
+        row += 1
 
 
     def get_active_ratings(self):
@@ -114,3 +158,18 @@ class RatingsMenuFrame(ctk.CTkFrame):
         """Return the min and max values for batting."""
         min_value, max_value = self.card_value_frame.get_min_max_values()
         return min_value, max_value
+
+    def get_min_max_year(self):
+        """Return the min and max year for batting."""
+        min_year, max_year = self.year_select_frame.get_min_max_year()
+        return min_year, max_year
+
+    def get_selected_position(self):
+        """Return the selected position for batting."""
+        position = self.position_select_frame.get_selected_position()
+        return position
+
+    def get_selected_card_type(self):
+        """Return the selected card_type for batting."""
+        selected_card_types = self.card_type_select_frame.get_selected_card_types()
+        return selected_card_types

--- a/utils/view_utils/year_value_select_frame.py
+++ b/utils/view_utils/year_value_select_frame.py
@@ -4,8 +4,15 @@ import customtkinter as ctk
 
 class YearValueSelectFrame(ctk.CTkFrame):
     """Frame for getting needed information from user."""
+
     def __init__(self, parent):
-        ctk.CTkFrame.__init__(self, parent, border_color='gray', border_width=2)
+        """Initialize of frame for selecting card years."""
+        ctk.CTkFrame.__init__(
+            self,
+            parent,
+            border_color='gray',
+            border_width=2
+        )
 
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
@@ -49,6 +56,7 @@ class YearValueSelectFrame(ctk.CTkFrame):
         self.max_entry.grid(row=1, column=3, padx=10, pady=10, sticky='nsew')
 
     def get_min_max_year(self):
+        """Return the minimum year and maximum year."""
         try:
             min_year = int(self.min_year.get())
         except ValueError:

--- a/utils/view_utils/year_value_select_frame.py
+++ b/utils/view_utils/year_value_select_frame.py
@@ -1,0 +1,62 @@
+"""Frame for selecting card years."""
+import customtkinter as ctk
+
+
+class YearValueSelectFrame(ctk.CTkFrame):
+    """Frame for getting needed information from user."""
+    def __init__(self, parent):
+        ctk.CTkFrame.__init__(self, parent, border_color='gray', border_width=2)
+
+        self.columnconfigure(0, weight=1)
+        self.columnconfigure(1, weight=1)
+        self.columnconfigure(2, weight=1)
+        self.columnconfigure(3, weight=1)
+
+        self.min_year = ctk.StringVar(value='1871')
+        self.max_year = ctk.StringVar(value='2025')
+
+        self.frame_label = ctk.CTkLabel(
+            self,
+            text='Year Select',
+        )
+        self.frame_label.grid(row=0, column=0, columnspan=4, sticky='nsew')
+
+        self.min_label = ctk.CTkLabel(
+            self,
+            text='Min'
+        )
+        self.min_label.grid(row=1, column=0)
+
+        self.min_entry = ctk.CTkEntry(
+            self,
+            textvariable=self.min_year,
+            width=40,
+        )
+        self.min_entry.grid(row=1, column=1)
+
+        self.max_label = ctk.CTkLabel(
+            self,
+            text='Max'
+        )
+        self.max_label.grid(row=1, column=2, padx=10, pady=10, sticky='nsew')
+
+        self.max_entry = ctk.CTkEntry(
+            self,
+            textvariable=self.max_year,
+            width=40,
+
+        )
+        self.max_entry.grid(row=1, column=3, padx=10, pady=10, sticky='nsew')
+
+    def get_min_max_year(self):
+        try:
+            min_year = int(self.min_year.get())
+        except ValueError:
+            min_year = 1850
+
+        try:
+            max_year = int(self.max_year.get())
+        except ValueError:
+            max_year = 2025
+
+        return min_year, max_year


### PR DESCRIPTION
v0.1.4.xxx 

Add functionality for players to compare card ratings using different weighted values of the player's choice.  

Uses the card dump from the OOTP card shop, along with Pandas Dataframes to display rating values in a custom frame built on customTKinter framework. 

Adds modular frames for tools, including card year selection, rating selection, card type selection, position radio buttons, and rating weight entry boxes.

Refactors team statistics code so that it will not dump all teams in small datasets, preventing display of team records with stats listed as 'not a number'.